### PR TITLE
Add user-timings-to-trace.mjs

### DIFF
--- a/generic-trace-to-devtools-trace.mjs
+++ b/generic-trace-to-devtools-trace.mjs
@@ -88,6 +88,7 @@ const busiestFrameId = busiestFrame?.at(0) ?? 'NOFRAMEIDFOUND';
  * @return {LH.TraceEvent}
  */
 function createFakeTracingStartedInPage() {
+  // TODO: migrate to TracingStartedInBrowser cuz this one is old.
   return {
     pid: busiestMainThread.pid,
     tid: busiestMainThread.tid,

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,10 @@ This repo is messy.
 
 * `bytes-in-trace-by-cat.mjs` - Emit data about what trace event names and categories take up byte size in the JSON
 * `format-trace.mjs` - Save a "properly formatted" version of the trace to a new file.
+* `user-timings-to-trace.mjs` - Take some user timings (performance.measure/mark) and generate a trace for visualization.
 * `winnow-trace.mjs` - Remove trace events to crop it to a timerange, exclude some category, etc. Save it to a new file.
 * `generic-trace-to-devtools-trace.mjs` - Take a trace captured from chrome://tracing or perfetto (but converted to json)… And convert it to a trace that DevTools can load as first-class. (not falling back to isGenericTrace handling)
+* `extract-netlog-from-trace.mjs` - Extract .netlog from a trace, to use in the [viewer](https://netlog-viewer.appspot.com/).
 * `extract-cpu-profile-from-trace.mjs` - Extract .cpuprofile from a trace. It'll create 1 or more .cpuprofiles next to the trace
 * `process-traces.mjs` - iterate over all traces found in a folder, run them through a trace processor to see what breaks.
 * `trace-file-utils.mjs` - loading, saving utilities.. matching whats in NPP & LH.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "forceConsistentCasingInFileNames": true,
 
 
-    "lib": ["es2020"]
+    "lib": ["ESNext", "dom"]
 
     // "listFiles": true,
     // "noErrorTruncation": true,

--- a/types/chromium-trace.d.ts
+++ b/types/chromium-trace.d.ts
@@ -32,6 +32,8 @@ export interface TraceEvent {
     };
     source_type?: string;
     data?: {
+      frameTreeNodeId?: number;
+      persistentIds?: boolean;
       frame?: string;
       isLoadingMainFrame?: boolean;
       documentLoaderURL?: string;

--- a/user-timings-to-trace.mjs
+++ b/user-timings-to-trace.mjs
@@ -49,7 +49,7 @@ export function generateTraceEvents(entries, threadId = 8) {
     processId: baseEvt.pid,
     frame: '_frameid_',
     name: '_frame_name_',
-    url: 'https://www.UNSET_URL.com/',
+    url: '',
     navigationId: '_navid_',
   };
 
@@ -135,16 +135,17 @@ export function generateTraceEvents(entries, threadId = 8) {
     currentTrace.push(endEvt);
   });
 
-  // DevTools likes having a real event to calculate trace bounds
+  // DevTools likes having a real event at the end to calculate trace bounds. 
+  // We'll give it a little breathing room for more enjoyable UI.
   const firstTs = (entries.at(0)?.startTime ?? 0) * 1000;
   const lastTs = currentTrace.at(-1)?.ts ?? currentTrace.reduce((acc, e) => (e.ts + (e.dur ?? 0) > acc ? e.ts + (e.dur ?? 0) : acc), 0);
-
+  const finalTs = 2.1 * lastTs - firstTs;
   const lastEvent = {
     ...baseEvt,
     name: 'RunTask',
     cat: 'disabled-by-default-devtools.timeline',
     ph: 'X',
-    ts: lastTs, // (lastTs - firstTs) * 1.1,
+    ts: finalTs,
     dur: 2,
   };
   currentTrace.push(lastEvent);

--- a/user-timings-to-trace.mjs
+++ b/user-timings-to-trace.mjs
@@ -1,6 +1,10 @@
+//  Take some user timings (performance.measure/mark) and generate a trace for visualization.
+//  Perfect if you instrment in Node.js with performance mark()/measure(), or the NPM marky package.
+//  Run like:
+//     node user-timings-to-trace.mjs user-timings.json
+//
 // Most of this file is from Lighthouse: https://github.com/GoogleChrome/lighthouse/blob/0da3e1d85d1920e3e75e423e6f905ddf4bd8fd53/core/lib/timing-trace-saver.js
 // But I've adapted it to be solo and modernized it a tad. ~Paul. 2024-10
-
 /**
  * @license
  * Copyright 2018 Google LLC

--- a/user-timings-to-trace.mjs
+++ b/user-timings-to-trace.mjs
@@ -1,0 +1,137 @@
+// Most of this file is from Lighthouse: https://github.com/GoogleChrome/lighthouse/blob/0da3e1d85d1920e3e75e423e6f905ddf4bd8fd53/core/lib/timing-trace-saver.js
+// But I've adapted it to be solo and modernized it a tad. ~Paul. 2024-10
+
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+performance.mark('top');
+
+
+import fs from 'fs';
+import path from 'path';
+
+performance.mark('importdone');
+
+/** @typedef {import('./types/chromium-trace').TraceEvent} TraceEvent */
+
+/**
+ * Generates a Chrome trace file from user timing measures
+ *
+ * Originally adapted from https://github.com/tdresser/performance-observer-tracing
+ * 
+ * @param {PerformanceEntryList} entries user timing entries
+ * @param {number=} threadId Can be provided to separate a series of trace events into another thread, useful if timings do not share the same timeOrigin, but should both be "left-aligned".
+ */
+export function generateTraceEvents(entries, threadId = 0) {
+  if (!Array.isArray(entries) || entries[0].entryType) return [];
+
+
+  /** @type {TraceEvent[]} */
+  const currentTrace = [];
+  entries.sort((a, b) => a.startTime - b.startTime);
+  entries.forEach((entry, i) => {
+    /** @type {TraceEvent} */
+    const startEvt = {
+      // FYI Colons in user_timing names get special handling in about:tracing you may not want. https://github.com/catapult-project/catapult/blob/b026043a43f9ce3f37c1cd57269f92cb8bee756c/tracing/tracing/extras/importer/trace_event_importer.html#L1643-L1654
+      // But no adjustments made here.
+      name: entry.name,
+      cat: 'blink.user_timing',
+      ts: entry.startTime * 1000,
+      args: {},
+      dur: 0,
+      pid: 0,
+      tid: threadId,
+      ph: 'b',
+      id: '0x' + (i++).toString(16),
+    };
+
+    const endEvt = {
+      ...startEvt,
+      ph: 'e', 
+      ts: startEvt.ts + (entry.duration * 1000),
+    };
+
+    currentTrace.push(startEvt);
+    currentTrace.push(endEvt);
+  });
+
+  // Add labels
+  /** @type {TraceEvent} */
+  const metaEvtBase = {
+    pid: 0,
+    tid: threadId,
+    ts: 0,
+    dur: 0,
+    ph: 'M',
+    cat: '__metadata',
+    name: 'process_labels',
+    args: {labels: 'Default'},
+  };
+  currentTrace.push(Object.assign({}, metaEvtBase, {args: {labels: 'User Timing'}}));
+
+  // Only inject TracingStartedInBrowser once
+  if (threadId === 0) {
+    currentTrace.push(Object.assign({}, metaEvtBase, {
+      'cat': 'disabled-by-default-devtools.timeline',
+      'name': 'TracingStartedInBrowser',
+      'ph': 'I',
+      'args': {'data': {
+        'frameTreeNodeId': 1,
+        'persistentIds': true,
+        'frames': [],
+      }},
+    }));
+  }
+  return currentTrace;
+}
+
+/**
+ * Writes a trace file to disk
+ * @param {PerformanceEntryList} entries
+ * @return {string}
+ */
+export function createTraceString(entries) {
+  performance.mark('genTrace-b');
+  const traceEvents = generateTraceEvents(entries);
+  performance.measure('generateTraceEvents', {start: 'gen-Trace-b', end: performance.now()});
+
+
+  performance.mark('stringify-b');
+
+  const jsonStr = `{"traceEvents":[
+${traceEvents.map(evt => JSON.stringify(evt)).join(',\n')}
+]}`;
+
+  performance.measure('stringify', {start: 'stringify-b', end: performance.now()});
+
+  return jsonStr;
+}
+
+
+// CLI direct invocation?
+if (import.meta.url.endsWith(process.argv[1])) {
+  cli();
+}
+
+async function cli() {
+  const filename = process.argv[2] && path.resolve(process.cwd(), process.argv[2]);
+  if (!filename || !fs.existsSync(filename)) {
+    throw new Error(`File not found: ${filename}`);
+  }
+
+  const entries = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  const jsonStr = createTraceString(entries);
+
+  const pathObj = path.parse(filename);
+  const traceFilePath = path.join(pathObj.dir, `${pathObj.name}.trace.json`);
+  fs.writeFileSync(traceFilePath, jsonStr, 'utf8');
+
+  console.log(`
+  > Timing trace saved to: ${traceFilePath}
+  > View in DevTools perf panel, Perfetto UI or https://trace.cafe
+`);
+}
+
+


### PR DESCRIPTION
Take some user timings (performance.measure/mark) and generate a trace for visualization.
Perfect if you instrment in Node.js with performance mark()/measure(), or the NPM marky package.

     node user-timings-to-trace.mjs user-timings.json

Use with CLI or with the exported methods.


Example:

```js
    performance.measure('all', '1', '4');
    performance.measure('read json', '1', '2');
    performance.measure('craft trace', '2', '3');
    performance.measure('write file', '3', '4');
    fs.writeFileSync('./selftimings.json', JSON.stringify(performance.getEntries()), 'utf8');
```

<img width="728" alt="image" src="https://github.com/user-attachments/assets/fdd13060-1245-44e2-88f7-eb0076e6f972">
<img width="1303" alt="image" src="https://github.com/user-attachments/assets/ba930f31-2a9e-4023-a499-2173276407ca">
